### PR TITLE
モックデータが正常に一覧表示されるように戻した

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,19 +4,15 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   pages: true,
 
+  modules: ["@nuxt/ui"],
+
   nitro: {
     handlers: [
-      { route: "/api/item", handler: "~/server/api/item.js", override: true },
-      {
-        route: "/api/spotify-token",
-        handler: "~/server/api/spotify.js",
-        override: true,
-      },
+      { route: "/api/item", handler: "~/server/api/item.js" },
+      { route: "/api/spotify-token", handler: "~/server/api/spotify.js" },
     ],
     routeRules: {
       "/api/**": { cors: true },
     },
   },
-
-  modules: ["@nuxt/ui"],
 });


### PR DESCRIPTION
nuxt.config.tsを以下のように変更しました

```
import { defineNuxtConfig } from "nuxt/config";

export default defineNuxtConfig({
  devtools: { enabled: true },
  pages: true,

  modules: ["@nuxt/ui"],

  nitro: {
    handlers: [
      { route: "/api/item", handler: "~/server/api/item.js" },
      { route: "/api/spotify-token", handler: "~/server/api/spotify.js" },
    ],
    routeRules: {
      "/api/**": { cors: true },
    },
  },
});

```